### PR TITLE
colormap Remove render method from each image/slice. 

### DIFF
--- a/src/nifti/Slice.js
+++ b/src/nifti/Slice.js
@@ -137,9 +137,6 @@ export default class Slice {
     const volumeMetaData = this.volume.metaData;
     const sliceMetaData = this.metaData;
     const cornerstone = external.cornerstone;
-    const render = volumeMetaData.dataType.isDataInColors
-      ? cornerstone.renderColorImage
-      : cornerstone.renderGrayscaleImage;
 
 
     return {
@@ -161,8 +158,7 @@ export default class Slice {
       windowWidth: volumeMetaData.windowWidth,
       floatPixelData: this.floatPixelData,
       decodeTimeInMS: 0,
-      getPixelData: () => this.pixelData,
-      render
+      getPixelData: () => this.pixelData
     };
   }
 


### PR DESCRIPTION
The logic of render (to decide which method to use) will be handled by cornerstone instead.